### PR TITLE
Add package specification for roadmap implementation

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -1,0 +1,186 @@
+# Cyberpony Express BBS Specification
+
+This document describes how the Cyberpony Express BBS package will be built to satisfy the roadmap.  It outlines module relationships, core function definitions and extension points.
+
+## Architectural overview
+
+```
+Meshtastic Radio ──USB── BBS Operator ──Queue── Service Host ──Plugins
+```
+
+* **Meshtastic Radio** – A T‑Beam or similar device running official Meshtastic firmware.
+* **BBS Operator** – Python module that communicates with the radio, parses packets and queues requests.
+* **Service Host** – Python framework that processes queued requests, runs services and sends replies.
+* **Plugins** – Modular services (mail, librarian, MUD, games) loaded by the service host.
+
+Both main packages live under `src/` and are designed for low power devices.  Operator and host interact through a simple queue that can be backed by files, memory or another store.
+
+## Phase 1 – Core BBS
+
+### Goals
+
+* Implement the `bbs_operator` package.
+* Implement the `service_host` framework.
+* Provide basic mail and bulletin board features.
+
+### bbs_operator package
+
+```
+src/bbs_operator/
+    __init__.py
+    operator.py
+    message.py
+    queue.py
+```
+
+#### operator.BBSOperator
+
+Connects to the Meshtastic device and routes packets into the message queue.
+
+* `BBSOperator(dev_path: str)` – constructor stores the serial device path.
+* `connect() -> None`
+    * Calls `meshtastic.serial_interface.SerialInterface` with `devPath`.
+    * Subscribes to `meshtastic.receive.text` via `pubsub.pub`.
+* `close() -> None` – closes the `SerialInterface`.
+* `on_receive(packet: dict, iface: SerialInterface) -> None`
+    * Extracts sender and text from the Meshtastic packet.
+    * Builds a `BBSMessage` object and pushes it to the queue.
+* `send_text(destination: str, text: str) -> dict`
+    * Wrapper around `SerialInterface.sendText` for use by the service host.
+
+#### message.BBSMessage
+
+Small dataclass representing incoming requests.
+
+* `sender_id: str`
+* `text: str`
+* `timestamp: float`
+* `context: dict | None`
+
+#### queue.MessageQueue
+
+Abstract queue with a file‑based default implementation.
+
+* `push(message: BBSMessage) -> None`
+* `pop() -> BBSMessage | None`
+* `ack(message: BBSMessage) -> None`
+
+The operator uses `push`, while the service host uses `pop` and `ack`.
+
+### service_host package
+
+```
+src/service_host/
+    __init__.py
+    host.py
+    handlers/
+        __init__.py
+        mail.py
+        board.py
+```
+
+#### host.ServiceHost
+
+Runs on the Raspberry Pi, polls the queue and dispatches messages to registered handlers.
+
+* `ServiceHost(operator: BBSOperator, queue: MessageQueue)`
+* `register_handler(command: str, handler: Callable[[BBSMessage], str]) -> None`
+* `run() -> None`
+    * Loop: `message = queue.pop()`.
+    * Determine command from `message.text`.
+    * Call the corresponding handler.
+    * Send reply via `operator.send_text`.
+    * Acknowledge processed messages.
+
+Handlers return plain text not exceeding the Meshtastic limit; the host is responsible for splitting long responses across multiple packets.
+
+#### handlers.mail
+
+Implements minimal personal mailboxes.
+
+* `handle_mail(message: BBSMessage) -> str`
+    * Parses subcommands: list, read, send.
+    * Stores messages under `data/mail/<user>/`.
+
+#### handlers.board
+
+Public bulletin board threads.
+
+* `handle_board(message: BBSMessage) -> str`
+    * Stores posts in `data/board/<thread>/`.
+
+### Relationships with Meshtastic library
+
+* `meshtastic.serial_interface.SerialInterface` provides the USB connection.
+* `pubsub.pub.subscribe` feeds received packets into `BBSOperator.on_receive`.
+* `SerialInterface.sendText` is used for outgoing replies.
+
+The operator hides these details so that handlers and plugins interact only with `BBSMessage` objects and `send_text`.
+
+### Extending phase 1
+
+Developers can add new commands by placing modules in `service_host/handlers/` and calling `register_handler`.  Handlers can maintain state in `data/` or external stores.
+
+## Phase 2 – Librarian chatbot & library
+
+### Goals
+
+* Retrieval‑augmented chatbot that answers questions from a local library.
+* Multi‑part message support for longer answers.
+
+### Implementation outline
+
+* Add `librarian` plugin under `service_host/handlers/`.
+* `handle_librarian(message: BBSMessage) -> list[str]`
+    * Uses a local RAG pipeline to generate short text segments.
+    * Returns a list of message parts; the service host loops over them when sending replies.
+* Extend `ServiceHost.send_reply` to accept a list of strings for multi‑part messages.
+
+Users may swap the RAG backend by providing an object with a `query(text: str) -> list[str]` interface.
+
+## Phase 3 – Multi‑User Dungeon and games
+
+### Goals
+
+* Provide a simple MUD engine and additional games.
+* Support persistent sessions.
+
+### Implementation outline
+
+* Create `mud` package under `service_host/handlers/` with a `GameSession` class.
+* `GameSession` stores player location, inventory and pending output.
+* `handle_mud(message: BBSMessage) -> str`
+    * Loads or creates a `GameSession` for `message.sender_id`.
+    * Interprets the command (look, move, talk).
+    * Returns the resulting narrative text.
+* Additional mini‑games follow the same pattern and register their own handlers.
+
+Sessions are persisted under `data/mud/<player_id>.json` so users can resume later.
+
+## Phase 4 – Federation & advanced features
+
+### Goals
+
+* Forward messages to remote BBS instances (store‑and‑forward).
+* Add scheduling, sensors and other data feeds.
+
+### Implementation outline
+
+* Introduce `federation` module with functions:
+    * `create_telegram(destination: str, payload: dict) -> Path`
+    * `process_telegram(path: Path) -> None`
+* `schedule` module for queued announcements:
+    * `schedule_message(time: datetime, text: str, destination: str) -> None`
+* Sensor integrations register periodic jobs that push notifications into the queue.
+
+## Extending and customizing
+
+The architecture encourages user customization:
+
+* **Handlers** – New commands are simple functions that accept `BBSMessage` and return text.  Users drop a module in `handlers/` and register it.
+* **Queue backend** – Implement the `MessageQueue` interface to switch between in‑memory, SQLite or distributed queues.
+* **Plugins** – Complex features (Librarian, MUD, federation) live in separate modules that can be enabled or disabled.
+* **Meshtastic options** – `BBSOperator` accepts additional keyword arguments forwarded to `SerialInterface` for advanced radio settings.
+
+By adhering to small, focused functions and clear naming, developers can easily understand and extend the system while staying within the constraints of the Meshtastic network.
+

--- a/src/bbs_operator/__init__.py
+++ b/src/bbs_operator/__init__.py
@@ -1,1 +1,12 @@
 """BBS operator package."""
+
+from .message import BBSMessage
+from .operator import BBSOperator
+from .queue import MessageQueue, FileMessageQueue
+
+__all__ = [
+    "BBSMessage",
+    "BBSOperator",
+    "MessageQueue",
+    "FileMessageQueue",
+]

--- a/src/bbs_operator/message.py
+++ b/src/bbs_operator/message.py
@@ -1,0 +1,13 @@
+"""Message structures for the BBS operator."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class BBSMessage:
+    """Represents a message received from the mesh."""
+
+    sender_id: str
+    text: str
+    timestamp: float
+    context: dict | None = None

--- a/src/bbs_operator/operator.py
+++ b/src/bbs_operator/operator.py
@@ -1,0 +1,41 @@
+"""Meshtastic operator that bridges the radio and the queue."""
+
+from time import time
+from pubsub import pub
+from meshtastic.serial_interface import SerialInterface
+
+from .message import BBSMessage
+from .queue import MessageQueue
+
+
+class BBSOperator:
+    """Connects to the Meshtastic device and queues incoming messages."""
+
+    def __init__(self, dev_path: str, queue: MessageQueue):
+        self.dev_path = dev_path
+        self.queue = queue
+        self.interface: SerialInterface | None = None
+
+    def connect(self) -> None:
+        self.interface = SerialInterface(devPath=self.dev_path)
+        pub.subscribe(self.on_receive, "meshtastic.receive.text")
+
+    def close(self) -> None:
+        if self.interface is None:
+            return
+        self.interface.close()
+        self.interface = None
+
+    def on_receive(self, packet: dict, iface: SerialInterface) -> None:
+        sender = str(packet.get("from", ""))
+        data = packet.get("decoded", {})
+        text = data.get("text", "")
+        now = time()
+        message = BBSMessage(sender_id=sender, text=text, timestamp=now)
+        self.queue.push(message)
+
+    def send_text(self, destination: str, text: str) -> dict:
+        if self.interface is None:
+            raise RuntimeError("Interface not connected")
+        packet = self.interface.sendText(text, destinationId=destination)
+        return packet

--- a/src/bbs_operator/queue.py
+++ b/src/bbs_operator/queue.py
@@ -1,0 +1,62 @@
+"""Queue implementations for BBS messages."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from pathlib import Path
+import json
+
+from .message import BBSMessage
+
+
+class MessageQueue:
+    """Abstract message queue."""
+
+    def push(self, message: BBSMessage) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def pop(self) -> BBSMessage | None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def ack(self, message: BBSMessage) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class FileMessageQueue(MessageQueue):
+    """Stores messages as JSON files."""
+
+    def __init__(self, directory: str | Path):
+        self.directory = Path(directory)
+        self.directory.mkdir(parents=True, exist_ok=True)
+
+    def push(self, message: BBSMessage) -> None:
+        path = self._path_for(message)
+        data = asdict(message)
+        with path.open("w", encoding="utf-8") as handle:
+            json.dump(data, handle)
+
+    def pop(self) -> BBSMessage | None:
+        files = sorted(self.directory.glob("*.json"))
+        if not files:
+            return None
+        path = files[0]
+        with path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+        data["context"] = {"path": str(path)}
+        message = BBSMessage(**data)
+        return message
+
+    def ack(self, message: BBSMessage) -> None:
+        path_str = None
+        if message.context is not None:
+            path_str = message.context.get("path")
+        if path_str is None:
+            return
+        path = Path(path_str)
+        if path.exists():
+            path.unlink()
+
+    def _path_for(self, message: BBSMessage) -> Path:
+        name = f"{message.timestamp}-{message.sender_id}.json"
+        path = self.directory / name
+        return path

--- a/src/service_host/__init__.py
+++ b/src/service_host/__init__.py
@@ -1,1 +1,5 @@
 """Service host package."""
+
+from .host import ServiceHost
+
+__all__ = ["ServiceHost"]

--- a/src/service_host/handlers/__init__.py
+++ b/src/service_host/handlers/__init__.py
@@ -1,0 +1,1 @@
+"""Handler modules for the service host."""

--- a/src/service_host/handlers/board.py
+++ b/src/service_host/handlers/board.py
@@ -1,0 +1,44 @@
+"""Public bulletin board handler."""
+
+from pathlib import Path
+from time import time
+
+from bbs_operator import BBSMessage
+
+BOARD_ROOT = Path("data/board")
+
+
+def handle_board(message: BBSMessage) -> str:
+    tokens = message.text.split()
+    if len(tokens) < 2:
+        return "Board commands: post <thread> <text>, read <thread>"
+    subcommand = tokens[1]
+    if subcommand == "read" and len(tokens) > 2:
+        return read_thread(tokens[2])
+    if subcommand == "post" and len(tokens) > 3:
+        thread = tokens[2]
+        text = " ".join(tokens[3:])
+        return post_thread(message.sender_id, thread, text)
+    return "Invalid board command."
+
+
+def read_thread(thread: str) -> str:
+    thread_dir = BOARD_ROOT / thread
+    files = sorted(thread_dir.glob("*.txt"))
+    lines = []
+    for path in files:
+        entry = path.read_text(encoding="utf-8")
+        lines.append(entry)
+    if not lines:
+        return "No posts."
+    return "\n".join(lines)
+
+
+def post_thread(sender_id: str, thread: str, text: str) -> str:
+    thread_dir = BOARD_ROOT / thread
+    thread_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = str(time())
+    path = thread_dir / f"{timestamp}.txt"
+    body = f"{sender_id}: {text}"
+    path.write_text(body, encoding="utf-8")
+    return "Post added."

--- a/src/service_host/handlers/board.py
+++ b/src/service_host/handlers/board.py
@@ -24,6 +24,8 @@ def handle_board(message: BBSMessage) -> str:
 
 def read_thread(thread: str) -> str:
     thread_dir = BOARD_ROOT / thread
+    if not thread_dir.exists():
+        return "Thread does not exist."
     files = sorted(thread_dir.glob("*.txt"))
     lines = []
     for path in files:

--- a/src/service_host/handlers/mail.py
+++ b/src/service_host/handlers/mail.py
@@ -1,0 +1,59 @@
+"""Personal mail handler."""
+
+from pathlib import Path
+from time import time
+
+from bbs_operator import BBSMessage
+
+MAIL_ROOT = Path("data/mail")
+
+
+def handle_mail(message: BBSMessage) -> str:
+    tokens = message.text.split()
+    if len(tokens) < 2:
+        return "Mail commands: list, read <n>, send <user> <text>"
+    subcommand = tokens[1]
+    if subcommand == "list":
+        return list_messages(message.sender_id)
+    if subcommand == "read" and len(tokens) > 2:
+        return read_message(message.sender_id, tokens[2])
+    if subcommand == "send" and len(tokens) > 3:
+        recipient = tokens[2]
+        text = " ".join(tokens[3:])
+        return send_message(message.sender_id, recipient, text)
+    return "Invalid mail command."
+
+
+def list_messages(user_id: str) -> str:
+    user_dir = MAIL_ROOT / user_id
+    user_dir.mkdir(parents=True, exist_ok=True)
+    files = sorted(user_dir.glob("*.txt"))
+    lines = []
+    for index, path in enumerate(files, start=1):
+        line = f"{index}: {path.name}"
+        lines.append(line)
+    if not lines:
+        return "No messages."
+    return "\n".join(lines)
+
+
+def read_message(user_id: str, index_str: str) -> str:
+    user_dir = MAIL_ROOT / user_id
+    files = sorted(user_dir.glob("*.txt"))
+    index = int(index_str) - 1
+    if index < 0 or index >= len(files):
+        return "Invalid message number."
+    path = files[index]
+    text = path.read_text(encoding="utf-8")
+    path.unlink()
+    return text
+
+
+def send_message(sender_id: str, recipient_id: str, text: str) -> str:
+    user_dir = MAIL_ROOT / recipient_id
+    user_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = str(time())
+    path = user_dir / f"{timestamp}.txt"
+    body = f"From {sender_id}: {text}"
+    path.write_text(body, encoding="utf-8")
+    return "Message sent."

--- a/src/service_host/handlers/mail.py
+++ b/src/service_host/handlers/mail.py
@@ -40,7 +40,10 @@ def list_messages(user_id: str) -> str:
 def read_message(user_id: str, index_str: str) -> str:
     user_dir = MAIL_ROOT / user_id
     files = sorted(user_dir.glob("*.txt"))
-    index = int(index_str) - 1
+    try:
+        index = int(index_str) - 1
+    except ValueError:
+        return "Invalid message number."
     if index < 0 or index >= len(files):
         return "Invalid message number."
     path = files[index]

--- a/src/service_host/host.py
+++ b/src/service_host/host.py
@@ -23,11 +23,15 @@ class ServiceHost:
             if message is None:
                 sleep(0.1)
                 continue
-            command = message.text.split()[0]
-            handler = self.handlers.get(command)
-            if handler is None:
-                reply = "Unknown command."
+            parts = message.text.split()
+            if not parts:
+                reply = "Empty command."
             else:
-                reply = handler(message)
+                command = parts[0]
+                handler = self.handlers.get(command)
+                if handler is None:
+                    reply = "Unknown command."
+                else:
+                    reply = handler(message)
             self.operator.send_text(message.sender_id, reply)
             self.queue.ack(message)

--- a/src/service_host/host.py
+++ b/src/service_host/host.py
@@ -1,0 +1,33 @@
+"""Service host that dispatches messages to handlers."""
+
+from time import sleep
+from typing import Callable
+
+from bbs_operator import BBSOperator, MessageQueue, BBSMessage
+
+
+class ServiceHost:
+    """Polls the queue and routes messages to handlers."""
+
+    def __init__(self, operator: BBSOperator, queue: MessageQueue):
+        self.operator = operator
+        self.queue = queue
+        self.handlers: dict[str, Callable[[BBSMessage], str]] = {}
+
+    def register_handler(self, command: str, handler: Callable[[BBSMessage], str]) -> None:
+        self.handlers[command] = handler
+
+    def run(self) -> None:
+        while True:
+            message = self.queue.pop()
+            if message is None:
+                sleep(0.1)
+                continue
+            command = message.text.split()[0]
+            handler = self.handlers.get(command)
+            if handler is None:
+                reply = "Unknown command."
+            else:
+                reply = handler(message)
+            self.operator.send_text(message.sender_id, reply)
+            self.queue.ack(message)


### PR DESCRIPTION
## Summary
- document architecture for bbs_operator and service_host
- outline roadmap phases and extension points
- implement core operator, queue, and host packages with mail and board handlers

## Testing
- `pip install meshtastic pubsub`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d9ccd7ac0832da51ba2263a869af2